### PR TITLE
Extra docker container params

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Alternatively, more advanced users can also run projects using Docker. While use
 
 It is advised to use [Watchtower](https://github.com/containrrr/watchtower) to automatically update the project container:
 
-    docker run -d --name watchtower --restart=unless-stopped -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --label-enable --cleanup --interval 3600
+    docker run -d --name watchtower --restart=unless-stopped -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --label-enable --cleanup --interval 3600 --include-restarting
 
 after which the project container can be run:
 
-    docker run -d --name archiveteam --label=com.centurylinklabs.watchtower.enable=true --restart=unless-stopped atdr.meo.ws/archiveteam/urls-grab --concurrent 1 YOURNICKHERE
+    docker run -d --name archiveteam --label=com.centurylinklabs.watchtower.enable=true --log-driver json-file --log-opt max-size=50m --restart=unless-stopped atdr.meo.ws/archiveteam/urls-grab --concurrent 1 YOURNICKHERE
 
 Be sure to replace `YOURNICKHERE` with the nickname that you want to be shown as on the tracker. There is no registration, just pick a nickname you like.
 


### PR DESCRIPTION
watchtower: `--include-restarting` also update if the container is in a crash loop due to a bad build or the like
grab container: `--log-driver json-file --log-opt max-size=50m` to limit logs, docker defaults to json-file with no limit